### PR TITLE
Reduce verbosity of logging for unbound events.

### DIFF
--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -285,7 +285,7 @@ class TestFreeSwitchESLProtocol(VumiTestCase):
         with LogCatcher() as lc:
             self.proto.unboundEvent({"some": "data"}, "custom_event")
             self.assertEqual(lc.messages(), [
-                "Unbound event 'custom_event': {'some': 'data'}",
+                "Unbound event 'custom_event'",
             ])
 
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -128,7 +128,7 @@ class FreeSwitchESLProtocol(EventProtocol):
         self.vumi_transport.deregister_client(self)
 
     def unboundEvent(self, evdata, evname):
-        log.msg("Unbound event %r: %r" % (evname, evdata))
+        log.msg("Unbound event %r" % (evname,))
 
 
 class VoiceServerTransportConfig(Transport.CONFIG_CLASS):


### PR DESCRIPTION
Currently we log the event data which turns out to be tens of lines long.
