### PR TITLE
send ack and nack depending on call setup result

### DIFF
--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -590,4 +590,3 @@ class TestVoiceClientTransport(VumiTestCase):
         self.assertEqual(nack['user_message_id'], msg['message_id'])
         self.assertEqual(nack['nack_reason'],
                          "Could not make call to client u'54321'")
-

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -573,7 +573,6 @@ class TestVoiceClientTransport(VumiTestCase):
         self.assertTrue(client_addr in self.worker._clients)
         yield self.hangup_client(client)
         self.assertFalse(client_addr in self.worker._clients)
-        foo = yield self.tx_helper.wait_for_dispatched_inbound(1)
         [hangup_msg] = yield (
             self.tx_helper.wait_for_dispatched_inbound(1))
         self.assertEqual(

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -573,7 +573,8 @@ class TestVoiceClientTransport(VumiTestCase):
         self.assertTrue(client_addr in self.worker._clients)
         yield self.hangup_client(client)
         self.assertFalse(client_addr in self.worker._clients)
-        [sent_msg, hangup_msg] = yield (
+        foo = yield self.tx_helper.wait_for_dispatched_inbound(1)
+        [hangup_msg] = yield (
             self.tx_helper.wait_for_dispatched_inbound(1))
         self.assertEqual(
             hangup_msg['session_event'], TransportUserMessage.SESSION_CLOSE)

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -133,7 +133,7 @@ class FreeSwitchESLProtocol(EventProtocol):
 
 
 class ClientConnectError(Exception):
-    pass
+    """Error for when a call could not be established."""
 
 
 class FreeSwitchESLClientProtocol(FreeSwitchESLProtocol):

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -375,9 +375,11 @@ class VoiceServerTransport(Transport):
         if (client is None and message.get('session_event') ==
                 TransportUserMessage.SESSION_NEW):
             try:
-                client = yield self.create_dialer_client(message['to_addr'])
+                client = yield self.create_dialer_client(client_addr)
                 yield client.make_call()
-            except ClientConnectError:
+            except ClientConnectError as e:
+                log.msg("Error connecting to client %r: %s" % (
+                    client_addr, e))
                 yield self.publish_nack(
                     message["message_id"],
                     "Could not make call to client %r" % (client_addr,))

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -156,7 +156,7 @@ class FreeSwitchESLClientProtocol(FreeSwitchESLProtocol):
             return response
 
         def _error(err):
-            raise ClientConnectError(err)
+            raise ClientConnectError(err.value)
 
         profile = self.vumi_transport.config.sofia_profile
         call_url = "sofia/%s/%s" % (profile, self.uniquecallid)

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -156,7 +156,7 @@ class FreeSwitchESLClientProtocol(FreeSwitchESLProtocol):
             return response
 
         def _error(err):
-            raise ClientConnectError(err.value)
+            raise ClientConnectError(err.value.ev)
 
         profile = self.vumi_transport.config.sofia_profile
         call_url = "sofia/%s/%s" % (profile, self.uniquecallid)
@@ -172,7 +172,9 @@ class FreeSwitchESLClientProtocol(FreeSwitchESLProtocol):
             if response == "+OK":
                 d.callback(content)
             else:
-                d.errback(ev)
+                e = Exception("bgapi error")
+                e.ev = ev
+                d.errback(e)
 
     @inlineCallbacks
     def onChannelHangup(self, ev):


### PR DESCRIPTION
Relies on https://github.com/praekelt/vumi-freeswitch-esl/issues/11 . Sends an ack if the outgoing call was set up correctly. Sends a nack if it wasn't.