### PR TITLE
Fix outbound voice calls.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,3 @@
 # Our dependencies are all specified in setup.py.
 
-# The following packages need to be installed from the their repositories
-# because we depend on dev versions. To upgrade, use the following command:
-#   pip install --exists-action i -U -r requirements.pip
-# This will ignore any existing repository clones. They can be updated manually
-# if desired.
-
--e git+https://github.com/praekelt/vumi.git#egg=vumi
-
 -e .

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'vumi',
-        # We need a dev versions of the packags above, so they have to be
-        # installed before us. They're listed first so that we fail fast
-        # instead of working through all the other requirements before
-        # discovering that they aren't available should that be the case.
+        'confmodel>=0.2.0',
         'Twisted>=13.1.0',
         'eventsocket==0.1.4',
     ],

--- a/vxfreeswitch/client.py
+++ b/vxfreeswitch/client.py
@@ -78,7 +78,9 @@ class FreeSwitchClient(object):
             raise FreeSwitchClientError(msg)
         except Exception as err:
             raise FreeSwitchClientError(str(err))
-        reply = FreeSwitchClientReply(*result.get('Reply_Text', '').split())
+        data = result.get('data', {})
+        rawresponse = data.get('rawresponse', '')
+        reply = FreeSwitchClientReply(*rawresponse.split())
         returnValue(reply)
 
     def api(self, api_call):

--- a/vxfreeswitch/client.py
+++ b/vxfreeswitch/client.py
@@ -1,0 +1,71 @@
+# -*- test-case-name: vxfreeswitch.tests.test_client -*-
+
+"""
+FreeSwitch ESL API client.
+"""
+
+from twisted.internet.protocol import ClientFactory
+from twisted.internet.defer import inlineCallbacks, Deferred
+
+from eventsocket import EventProtocol
+
+
+class FreeswitchClientError(Exception):
+    """ Error raised while using the Freeswitch client. """
+
+
+class FreeSwitchClientProtocol(EventProtocol):
+    """ Freeswitch ESL client.
+
+    :param str auth:
+        Authentication string to send to FreeSwitch.
+    """
+
+    def __init__(self, auth):
+        EventProtocol.__init__(self)
+        self._auth = auth
+        self.connected = Deferred()
+
+    @inlineCallbacks
+    def connectionMade(self):
+        if self._auth_credentials:
+            yield self.auth(self._auth_credentials)
+        self.connected.callback(self)
+
+
+class FreeSwitchClientFactory(ClientFactory):
+    """ FreeSwitch ESL client factory. """
+    def __init__(self, auth):
+        ClientFactory.__init__(self)
+        self.auth = auth
+
+    def protocol(self):
+        return FreeSwitchClientProtocol(self.auth)
+
+
+class FreeSwitchClient(object):
+    """ Helper class for making simple API calls to the FreeSwitch ESL
+    server.
+
+    :type endpoint:
+        Twisted client endpoint.
+    :param endpoint:
+        Endpoint for connecting to FreeSwitch over.
+
+    :param str auth:
+        Authentication string to send to FreeSwitch on connect.
+    """
+    def __init__(self, endpoint, auth=None):
+        self.endpoint = endpoint
+        self.factory = FreeSwitchClientFactory(auth)
+
+    def _connect(self):
+        """ Return a connected client or fail. """
+        d = self.endpoint.connect(self.factory)
+        d.addCallback(lambda client: client.connected)
+        return d
+
+    def api(self, api_call):
+        d = self._connect()
+        d.addCallback(lambda client: client.api(api_call))
+        return d

--- a/vxfreeswitch/originate.py
+++ b/vxfreeswitch/originate.py
@@ -1,0 +1,115 @@
+# -*- test-case-name: vxfreeswitch.tests.test_originate -*-
+
+"""
+Utilities for creating originate FreeSwitch API calls.
+"""
+
+
+class OriginateParamsError(Exception):
+    """ Error raised while formatting originate call parameters. """
+
+
+class OriginateFormatter(object):
+    """Helper for constructing originate calls.
+
+    This formatter uses a set of parameters to construct a template. The
+    template itself is then used to construct the API call from the to and
+    from addresses used by the call. The example lower down should make this
+    clearer.
+
+    :param str call_url:
+        The Freeswitch sofia 'url' to originate the call to.
+        Example: 'sofia/gateway/yogisip/{to_addr}'.
+
+    :param str exten:
+        The Freeswitch extension to link the call to. Example: '{from_addr}'.
+
+    :param str cid_name:
+        The caller ID name the call should appear from.  Sometimes
+        required to be set by external SIP gateways such as Twilio.
+        Example: 'yourapp'.
+
+    :param str cid_num:
+        The caller ID number the call should appear from.  Sometimes
+        required to be set by external SIP gateways such as
+        Twilio. Example: '{from_addr}'.
+
+    :param str dialplan:
+        The Freeswitch dialplan to use. Default: 'XML'.
+
+    :param str context:
+        The Freeswitch context to use. Default: 'default'.
+
+    :param int timeout:
+        The seconds to wait before timing out the dialing attempt.
+
+    :raises OriginateParamsError:
+        If required format parameters are not supplied.
+
+    The Freeswitch originate API call format is:
+
+      Usage: originate <call_url> <exten>|&<application_name>(<app_args>)
+             [<dialplan>] [<context>] [<cid_name>] [<cid_num>] [<timeout>]
+
+    It's rather complex and the details of each value are dependent on
+    the Freeswitch configuration.
+
+    E.g. ::
+
+        formatter = OriginateFormatter(
+            call_url='sofia/gateway/yogisip/{to_addr}',
+            exten='{from_addr}',
+            cid_name='vxfreeswitch',
+            cid_id='{from_addr}',
+        })
+
+        api_call = formatter.format_call(
+            to_addr="+1234", from_addr="+100")
+
+        # api_call == (
+        #     "originate sofia/gateway/yogisip/+1234 +100 XML default"
+        #     " vxfreeswitch +100 60"
+    """
+
+    PROTO_TEMPLATE = (
+        "originate %(call_url)s %(exten)s %(dialplan)s %(context)s"
+        " %(cid_name)s %(cid_num)s %(timeout)s"
+    )
+
+    DEFAULT_PARAMS = {
+        'dialplan': 'XML',
+        'context': 'default',
+        'timeout': 60,
+    }
+
+    def __init__(self, **kw):
+        self.template = self.format_template(**kw)
+
+    def format_call(self, from_addr, to_addr):
+        """ Return a formatted originate call.
+
+        :param str from_addr:
+            The address the call is from.
+
+        :param str to_addr:
+            The address the call is to.
+
+        :returns str:
+            A formatted originate call for passing to Freeswitch.
+        """
+        return self.template.format(
+            from_addr=from_addr, to_addr=to_addr)
+
+    @classmethod
+    def format_template(cls, **kw):
+        """ Format a template for constructing originate calls.
+
+        Parameters are as for the :class:`OriginateFormatter` class.
+        """
+        d = cls.DEFAULT_PARAMS.copy()
+        d.update(kw)
+        try:
+            return cls.PROTO_TEMPLATE % d
+        except KeyError as err:
+            raise OriginateParamsError(
+                "Missing originate parameter '%s'" % err)

--- a/vxfreeswitch/originate.py
+++ b/vxfreeswitch/originate.py
@@ -5,8 +5,8 @@ Utilities for creating originate FreeSwitch API calls.
 """
 
 
-class OriginateParamsError(Exception):
-    """ Error raised while formatting originate call parameters. """
+class OriginateMissingParameter(Exception):
+    """ Raised if required originate parameters are missing. """
 
 
 class OriginateFormatter(object):
@@ -111,5 +111,5 @@ class OriginateFormatter(object):
         try:
             return cls.PROTO_TEMPLATE % d
         except KeyError as err:
-            raise OriginateParamsError(
-                "Missing originate parameter '%s'" % err)
+            raise OriginateMissingParameter(
+                "Missing originate parameter %s" % err)

--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -149,6 +149,7 @@ class RecordingServer(Protocol):
 class FixtureResponse(object):
     """ A response to an ESL command. """
 
+    AUTH_REQUEST = 'auth/request'
     API_RESPONSE = 'api/response'
     REPLY = 'command/reply'
     EVENT = 'text/event-plain'
@@ -176,6 +177,15 @@ class FixtureReply(FixtureResponse):
     def __init__(self, *args):
         headers = [("Reply-Text", " ".join(args))]
         super(FixtureReply, self).__init__(self.REPLY, headers=headers)
+
+
+class FixtureAuthResponse(FixtureResponse):
+    """ A response to an auth request. """
+
+    def __init__(self, *args):
+        headers = [("Reply-Text", " ".join(args))]
+        super(FixtureAuthResponse, self).__init__(
+            self.AUTH_REQUEST, headers=headers)
 
 
 class FixtureApiResponse(FixtureResponse):

--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -1,0 +1,300 @@
+""" Test helpers for vxfreeswitch. """
+
+from uuid import uuid4
+
+from zope.interface import implements
+
+from twisted.internet import reactor
+from twisted.internet.defer import (
+    inlineCallbacks, returnValue, DeferredQueue, Deferred)
+from twisted.internet.endpoints import TCP4ServerEndpoint
+from twisted.internet.protocol import Protocol, Factory, ClientFactory
+from twisted.protocols.basic import LineReceiver
+from twisted.test.proto_helpers import StringTransport
+
+from vumi.tests.helpers import IHelper, proxyable
+
+
+class EslCommand(object):
+    """
+    An object representing an ESL command.
+    """
+    def __init__(self, cmd_type, params=None):
+        self.cmd_type = cmd_type
+        self.params = params if params is not None else {}
+
+    def __repr__(self):
+        return "<%s cmd_type=%r params=%r>" % (
+            self.__class__.__name__, self.cmd_type, self.params)
+
+    def __eq__(self, other):
+        if not isinstance(other, EslCommand):
+            return NotImplemented
+        return (self.cmd_type == other.cmd_type and
+                self.params == other.params)
+
+    def __getitem__(self, name):
+        return self.params.get(name)
+
+    def __setitem__(self, name, value):
+        self.params[name] = value
+
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Convert a dict to an :class:`EslCommand`.
+        """
+        cmd_type = d.get("type")
+        params = {
+            "call-command": d.get("call-command", "execute"),
+            "event-lock": d.get("event-lock", "true"),
+        }
+        if "name" in d:
+            params["execute-app-name"] = d.get("name")
+        if "arg" in d:
+            params["execute-app-arg"] = d.get("arg")
+        return cls(cmd_type, params)
+
+
+class EslParser(object):
+    """
+    Simple in-efficient parser for the FreeSwitch eventsocket protocol.
+    """
+
+    def __init__(self):
+        self.data = ""
+
+    def parse(self, new_data):
+        data = self.data + new_data
+        cmds = []
+        while "\n\n" in data:
+            cmd_data, data = data.split("\n\n", 1)
+            command = EslCommand("unknown")
+            first_line = True
+            for line in cmd_data.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                if first_line:
+                    command.cmd_type = line.strip()
+                    first_line = False
+                    continue
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    command[key] = value.strip()
+            cmds.append(command)
+        self.data = data
+        return cmds
+
+
+class EslTransport(StringTransport):
+
+    def __init__(self):
+        StringTransport.__init__(self)
+        self.cmds = DeferredQueue()
+        self.esl_parser = EslParser()
+
+    def write(self, data):
+        StringTransport.write(self, data)
+        for cmd in self.esl_parser.parse(data):
+            self.cmds.put(cmd)
+
+
+class RecordingServer(Protocol):
+    def __init__(self):
+        self.command_parser = EslParser()
+
+    def connectionMade(self):
+        self.factory.clients.append(self)
+
+    def _send_event(self, content):
+        self.transport.write(
+            'Content-Length: %s\n' % len(content) +
+            'Content-Type: text/event-plain\n\n' +
+            content)
+
+    def dataReceived(self, line):
+        commands = self.command_parser.parse(line)
+        #self.factory.data.extend(commands)
+        for cmd in commands:
+            response = self.factory.get_response(cmd)
+            self.transport.write(response.to_bytes())
+            continue
+            uuid = '%s' % self.factory.uuid()
+            # Send job received correctly
+            self.transport.write(
+                'Content-Type: command/reply\n'
+                'Reply-Text: +OK\n'
+                'Job-UUID: %s\n\n' % uuid)
+            if cmd.cmd_type.startswith('bgapi originate'):
+                # Send job complete success response
+                if self.factory.fail_connect:
+                    content_body = '+ERROR %s\n' % uuid
+                else:
+                    content_body = '+OK %s\n' % uuid
+                content = (
+                    'Content-Length: %d\n'
+                    'Event-Name: BACKGROUND_JOB\n'
+                    'Job-UUID: %s\n\n'
+                    '%s' %
+                    (len(content_body), uuid, content_body))
+                self._send_event(content)
+
+    def hangup(self):
+        content = (
+            'Event-Name: CHANNEL_HANGUP\n')
+        self._send_event(content)
+
+
+class FixtureResponse(object):
+    """ A response to an ESL command. """
+
+    REPLY = 'command/reply'
+    EVENT = 'text/event-plain'
+
+    def __init__(self, content, content_type):
+        self.content = content
+        self.content_type = content_type
+
+    def to_bytes(self):
+        return (
+            "Content-Type: %s\n"
+            "%s\n\n"
+        ) % (self.content_type, self.content)
+
+
+class FixtureReply(FixtureResponse):
+    """ A reply to an ESL command. """
+
+    def __init__(self, *args):
+        content = "Reply-Text: %s" % " ".join(args)
+        super(FixtureReply, self).__init__(content, self.REPLY)
+
+
+class FixtureNotFound(Exception):
+    """ Raise when a recording server has no matching fixture. """
+
+
+class RecordingServerFactory(Factory):
+    """ Factory for RecordingServer protocols. """
+
+    protocol = RecordingServer
+
+    def __init__(self, fail_connect=False, uuid=uuid4):
+        self.fixtures = []
+        self.clients = []
+
+    def add_fixture(self, cmd, response):
+        self.fixtures.append((cmd, response))
+
+    def get_response(self, received_cmd):
+        for i, (cmd, response) in enumerate(self.fixtures):
+            if received_cmd == cmd:
+                del self.fixtures[i]
+                return response
+        raise FixtureNotFound(received_cmd)
+
+
+class FakeFreeSwitchProtocol(LineReceiver):
+    """ A fake connection from FreeSwitch. """
+
+    def __init__(self, call_uuid):
+        self.call_uuid = call_uuid
+        self.esl_parser = EslParser()
+        self.queue = DeferredQueue()
+        self.connect_d = Deferred()
+        self.disconnect_d = Deferred()
+        self.setRawMode()
+
+    def connectionMade(self):
+        self.connected = True
+        self.connect_d.callback(None)
+
+    def sendPlainEvent(self, name, params=None):
+        params = {} if params is None else params
+        params['Event-Name'] = name
+        data = "\n".join("%s: %s" % (k, v) for k, v in params.items()) + "\n"
+        self.sendLine(
+            'Content-Length: %d\nContent-Type: text/event-plain\n\n%s' %
+            (len(data), data))
+
+    def sendCommandReply(self, params=""):
+        self.sendLine('Content-Type: command/reply\nReply-Text: +OK\n%s\n\n' %
+                      params)
+
+    def sendChannelHangupEvent(self):
+        self.sendPlainEvent('Channel_Hangup')
+
+    def sendDtmfEvent(self, digit):
+        self.sendPlainEvent('DTMF', {
+            'DTMF-Digit': digit,
+        })
+
+    def sendDisconnectEvent(self):
+        self.sendLine('Content-Type: text/disconnect-notice\n\n')
+
+    def rawDataReceived(self, data):
+        for cmd in self.esl_parser.parse(data):
+            if cmd.cmd_type == "connect":
+                self.sendCommandReply(
+                    'variable-call-uuid: %s' % self.call_uuid)
+            elif cmd.cmd_type == "myevents":
+                self.sendCommandReply()
+            elif cmd.cmd_type == "sendmsg":
+                self.sendCommandReply()
+                cmd_name = cmd.params.get('execute-app-name')
+                if cmd_name == "speak":
+                    self.queue.put(cmd)
+                elif cmd_name == "playback":
+                    self.queue.put(cmd)
+
+    def connectionLost(self, reason):
+        self.connected = False
+        self.disconnect_d.callback(None)
+
+
+class EslHelper(object):
+    """
+    Test helper for working with ESL servers.
+    """
+
+    implements(IHelper)
+
+    def __init__(self):
+        self._recorders = []
+        self._clients = []
+
+    def setup(self):
+        pass
+
+    @inlineCallbacks
+    def cleanup(self):
+        for server, factory in self._recorders:
+            yield server.stopListening()
+            for client in factory.clients:
+                yield client.transport.loseConnection()
+        for client in self._clients:
+            if client.transport and client.transport.connected:
+                client.sendDisconnectEvent()
+                yield client.transport.loseConnection()
+                yield client.disconnect_d
+
+    @proxyable
+    @inlineCallbacks
+    def mk_server(self, port=1337, fail_connect=False, uuid=uuid4):
+        endpoint = TCP4ServerEndpoint(reactor, port)
+        factory = RecordingServerFactory(fail_connect=fail_connect, uuid=uuid)
+        server = yield endpoint.listen(factory)
+        self._recorders.append((server, factory))
+        returnValue(factory)
+
+    @proxyable
+    @inlineCallbacks
+    def mk_client(self, worker, call_uuid="test-uuid"):
+        addr = worker.voice_server.getHost()
+        client = FakeFreeSwitchProtocol(call_uuid)
+        self._clients.append(client)
+        factory = ClientFactory.forProtocol(lambda: client)
+        yield reactor.connectTCP("127.0.0.1", addr.port, factory)
+        yield client.connect_d
+        returnValue(client)

--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -115,30 +115,9 @@ class RecordingServer(Protocol):
 
     def dataReceived(self, line):
         commands = self.command_parser.parse(line)
-        #self.factory.data.extend(commands)
         for cmd in commands:
             response = self.factory.get_response(cmd)
             self.transport.write(response.to_bytes())
-            continue
-            uuid = '%s' % self.factory.uuid()
-            # Send job received correctly
-            self.transport.write(
-                'Content-Type: command/reply\n'
-                'Reply-Text: +OK\n'
-                'Job-UUID: %s\n\n' % uuid)
-            if cmd.cmd_type.startswith('bgapi originate'):
-                # Send job complete success response
-                if self.factory.fail_connect:
-                    content_body = '+ERROR %s\n' % uuid
-                else:
-                    content_body = '+OK %s\n' % uuid
-                content = (
-                    'Content-Length: %d\n'
-                    'Event-Name: BACKGROUND_JOB\n'
-                    'Job-UUID: %s\n\n'
-                    '%s' %
-                    (len(content_body), uuid, content_body))
-                self._send_event(content)
 
     def hangup(self):
         content = (

--- a/vxfreeswitch/tests/test_client.py
+++ b/vxfreeswitch/tests/test_client.py
@@ -1,15 +1,206 @@
 """ Tests for vxfreeswitch.client. """
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, Deferred
+from twisted.internet.protocol import ClientFactory
+from twisted.test.proto_helpers import StringTransportWithDisconnection
+from twisted.python.failure import Failure
 from twisted.trial.unittest import TestCase
 
-from vxfreeswitch.client import FreeSwitchClient
+from eventsocket import EventError
+
+from vxfreeswitch.client import (
+    FreeSwitchClientProtocol, FreeSwitchClientFactory,
+    FreeSwitchClient, FreeSwitchClientReply, FreeSwitchClientError)
+
+
+def connect_transport(protocol):
+    """ Connect a StringTransport to a client protocol. """
+    factory = ClientFactory()
+    transport = StringTransportWithDisconnection()
+    protocol.makeConnection(transport)
+    transport.protocol = protocol
+    protocol.factory = factory
+    return transport
+
+
+class TestFreeSwitchClientProtocol(TestCase):
+    def test_connected(self):
+        p = FreeSwitchClientProtocol(auth=None)
+        self.assertTrue(isinstance(p._connected, Deferred))
+        self.assertEqual(p._connected.called, False)
+        connect_transport(p)
+        self.assertEqual(p._connected.called, True)
+        self.assertEqual(p._connected.result, p)
+
+    def test_auth(self):
+        p = FreeSwitchClientProtocol(auth="pw-12345")
+        tr = connect_transport(p)
+        self.assertEqual(tr.value(), "auth pw-12345\n\n")
+
+    def test_no_auth(self):
+        p = FreeSwitchClientProtocol(auth=None)
+        tr = connect_transport(p)
+        self.assertEqual(tr.value(), "")
+
+
+class TestFreeSwitchClientFactory(TestCase):
+    def test_subclasses_client_factory(self):
+        f = FreeSwitchClientFactory()
+        self.assertTrue(isinstance(f, ClientFactory))
+
+    def test_protocol(self):
+        f = FreeSwitchClientFactory()
+        p = f.protocol()
+        self.assertTrue(isinstance(p, FreeSwitchClientProtocol))
+
+    def test_default_noisy(self):
+        f = FreeSwitchClientFactory()
+        self.assertEqual(f.noisy, False)
+
+    def test_set_noisy(self):
+        f = FreeSwitchClientFactory(noisy=True)
+        self.assertEqual(f.noisy, True)
+
+    def test_no_auth(self):
+        f = FreeSwitchClientFactory()
+        p = f.protocol()
+        tr = connect_transport(p)
+        self.assertEqual(tr.value(), "")
+
+    def test_auth(self):
+        f = FreeSwitchClientFactory(auth="pw-1234")
+        p = f.protocol()
+        tr = connect_transport(p)
+        self.assertEqual(tr.value(), "auth pw-1234\n\n")
+
+
+class TestFreeSwitchClientError(TestCase):
+    def test_subclasses_exception(self):
+        err = FreeSwitchClientError("foo")
+        self.assertTrue(isinstance(err, Exception))
+
+    def test_str(self):
+        err = FreeSwitchClientError("reason")
+        self.assertEqual(str(err), "reason")
+
+
+class TestFreeSwitchClientReply(TestCase):
+    def test_args(self):
+        reply = FreeSwitchClientReply("a", "b")
+        self.assertEqual(reply.args, ("a", "b"))
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(FreeSwitchClientReply("a", "c")),
+            "<FreeSwitchClientReply args=('a', 'c')>")
+
+    def test_equal(self):
+        self.assertEqual(
+            FreeSwitchClientReply("a", "b"),
+            FreeSwitchClientReply("a", "b"))
+
+    def test_not_equal(self):
+        self.assertNotEqual(
+            FreeSwitchClientReply("a", "b"),
+            FreeSwitchClientReply("a", "c"))
+
+    def test_not_equal_other_object(self):
+        self.assertNotEqual(
+            FreeSwitchClientReply("a", "b"),
+            object())
 
 
 class TestFreeSwitchClient(TestCase):
     def mk_client(self, auth=None):
         endpoint = "XXX"
         return FreeSwitchClient(endpoint, auth)
+
+    def test_fallback_error_handler_client_error(self):
+        client = self.mk_client()
+        failure = Failure(FreeSwitchClientError("reason"))
+        self.assertEqual(
+            client.fallback_error_handler(failure), failure)
+
+    def test_fallback_error_handler_other_error(self):
+        client = self.mk_client()
+        failure = Failure(Exception("reason"))
+        err = self.failUnlessRaises(
+            FreeSwitchClientError,
+            client.fallback_error_handler, failure)
+        self.assertEqual(str(err), "reason")
+
+    def test_event_error_handler_event_error_has_reply(self):
+        client = self.mk_client()
+        failure = Failure(EventError({"Reply_Text": "+ERROR eep"}))
+        err = self.failUnlessRaises(
+            FreeSwitchClientError,
+            client.event_error_handler, failure)
+        self.assertEqual(str(err), "+ERROR eep")
+
+    def test_event_error_handler_event_error_no_reply(self):
+        client = self.mk_client()
+        failure = Failure(EventError({"Not_Reply": "foo"}))
+        err = self.failUnlessRaises(
+            FreeSwitchClientError,
+            client.event_error_handler, failure)
+        self.assertEqual(str(err), "{'Not_Reply': 'foo'}")
+
+    def test_event_error_handler_other_error(self):
+        client = self.mk_client()
+        failure = Failure(Exception("reason"))
+        self.assertEqual(
+            client.event_error_handler(failure), failure)
+
+    def test_request_callback_with_reply(self):
+        client = self.mk_client()
+        self.assertEqual(
+            client.request_callback({'Reply_Text': 'a b'}),
+            FreeSwitchClientReply('a', 'b'))
+
+    def test_request_callback_without_reply(self):
+        client = self.mk_client()
+        self.assertEqual(
+            client.request_callback({}),
+            FreeSwitchClientReply())
+
+    def test_api_request_callback_with_okay_response(self):
+        client = self.mk_client()
+        self.assertEqual(
+            client.api_request_callback({
+                'data': {
+                    'rawresponse': '+OK meep moop'
+                }
+            }),
+            FreeSwitchClientReply('+OK', 'meep', 'moop'))
+
+    def test_api_request_callback_with_error_response(self):
+        client = self.mk_client()
+        err = self.failUnlessRaises(
+            FreeSwitchClientError,
+            client.api_request_callback, {
+                'data': {
+                    'rawresponse': '+ERROR meep moop'
+                }
+            })
+        self.assertEqual(str(err), "+ERROR meep moop")
+
+    def test_api_request_callback_without_data(self):
+        client = self.mk_client()
+        err = self.failUnlessRaises(
+            FreeSwitchClientError,
+            client.api_request_callback, {
+                'foo': 'bar',
+            })
+        self.assertEqual(str(err), "{'foo': 'bar'}")
+
+    def test_api_request_callback_without_rawresponse(self):
+        client = self.mk_client()
+        err = self.failUnlessRaises(
+            FreeSwitchClientError,
+            client.api_request_callback, {
+                'data': {}
+            })
+        self.assertEqual(str(err), "{'data': {}}")
 
     @inlineCallbacks
     def test_with_connection(self):

--- a/vxfreeswitch/tests/test_client.py
+++ b/vxfreeswitch/tests/test_client.py
@@ -1,0 +1,37 @@
+""" Tests for vxfreeswitch.client. """
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import TestCase
+
+from vxfreeswitch.client import FreeSwitchClient
+
+
+class TestFreeSwitchClient(TestCase):
+    def mk_client(self, auth=None):
+        endpoint = "XXX"
+        return FreeSwitchClient(endpoint, auth)
+
+    @inlineCallbacks
+    def test_with_connection(self):
+        def f(conn):
+            return conn.do_something()
+
+        client = self.mk_client()
+        result = yield client.with_connection(f)
+        self.assertEqual(result, "XXX")
+
+    @inlineCallbacks
+    def test_api(self):
+        client = self.mk_client()
+        result = yield client.api("foo")
+        self.assertEqual(result, "XXX")
+
+    @inlineCallbacks
+    def test_auth(self):
+        def f(conn):
+            return
+
+        client = self.mk_client(auth="kenny")
+        result = yield client.with_connection(f)
+        self.assertEqual(result, "XXX")
+        self.assertTrue(authenticated)

--- a/vxfreeswitch/tests/test_originate.py
+++ b/vxfreeswitch/tests/test_originate.py
@@ -7,27 +7,51 @@ from vxfreeswitch.originate import (
 
 
 class TestOriginateFormatter(TestCase):
-    def mk_template(self, **kw):
+    def mk_params(self, **kw):
         params = {
             'call_url': 'sofia/gateway/yogisip/{to_addr}',
             'exten': '100',
             'cid_name': 'elcid',
-            'cid_num': '1099',
+            'cid_num': '{from_addr}',
         }
         params.update(kw)
         params = dict((k, v) for k, v in params.items() if v is not None)
-        return OriginateFormatter.format_template(**params)
+        return params
+
+    def mk_template(self, **kw):
+        return OriginateFormatter.format_template(**self.mk_params(**kw))
+
+    def mk_formatter(self, **kw):
+        return OriginateFormatter(**self.mk_params(**kw))
 
     def test_format_template(self):
         self.assertEqual(
             self.mk_template(),
             "originate sofia/gateway/yogisip/{to_addr}"
-            " 100 XML default elcid 1099 60"
-        )
+            " 100 XML default elcid {from_addr} 60")
 
-    def test_format_template_missing_parameters(self):
+    def test_format_template_missing_parameter(self):
         err = self.assertRaises(
             OriginateMissingParameter,
-            self.mk_template, call_url=None,
-        )
+            self.mk_template, call_url=None)
         self.assertEqual(str(err), "Missing originate parameter 'call_url'")
+
+    def test_init(self):
+        formatter = self.mk_formatter()
+        self.assertEqual(
+            formatter.template,
+            "originate sofia/gateway/yogisip/{to_addr}"
+            " 100 XML default elcid {from_addr} 60")
+
+    def test_init_missing_parameter(self):
+        err = self.assertRaises(
+            OriginateMissingParameter,
+            self.mk_formatter, cid_name=None)
+        self.assertEqual(str(err), "Missing originate parameter 'cid_name'")
+
+    def test_format_call(self):
+        formatter = self.mk_formatter()
+        self.assertEqual(
+            formatter.format_call(to_addr="+1234", from_addr="1099"),
+            "originate sofia/gateway/yogisip/+1234"
+            " 100 XML default elcid 1099 60")

--- a/vxfreeswitch/tests/test_originate.py
+++ b/vxfreeswitch/tests/test_originate.py
@@ -1,0 +1,33 @@
+""" Tests for vxfreeswitch.originate. """
+
+from twisted.trial.unittest import TestCase
+
+from vxfreeswitch.originate import (
+    OriginateFormatter, OriginateMissingParameter)
+
+
+class TestOriginateFormatter(TestCase):
+    def mk_template(self, **kw):
+        params = {
+            'call_url': 'sofia/gateway/yogisip/{to_addr}',
+            'exten': '100',
+            'cid_name': 'elcid',
+            'cid_num': '1099',
+        }
+        params.update(kw)
+        params = dict((k, v) for k, v in params.items() if v is not None)
+        return OriginateFormatter.format_template(**params)
+
+    def test_format_template(self):
+        self.assertEqual(
+            self.mk_template(),
+            "originate sofia/gateway/yogisip/{to_addr}"
+            " 100 XML default elcid 1099 60"
+        )
+
+    def test_format_template_missing_parameters(self):
+        err = self.assertRaises(
+            OriginateMissingParameter,
+            self.mk_template, call_url=None,
+        )
+        self.assertEqual(str(err), "Missing originate parameter 'call_url'")

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -5,9 +5,7 @@
 import md5
 import os
 
-from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.internet.protocol import ClientFactory
-from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
 
 from vumi.message import TransportUserMessage
 from vumi.tests.helpers import VumiTestCase
@@ -17,7 +15,7 @@ from vumi.transports.tests.helpers import TransportHelper
 from vxfreeswitch import VoiceServerTransport
 from vxfreeswitch.voice import FreeSwitchESLProtocol
 from vxfreeswitch.tests.helpers import (
-    EslCommand, EslHelper, EslTransport, FixtureReply)
+    EslCommand, EslHelper, EslTransport, FixtureApiResponse)
 
 
 class TestFreeSwitchESLProtocol(VumiTestCase):
@@ -325,7 +323,7 @@ class TestVoiceClientTransport(VumiTestCase):
         factory.add_fixture(
             EslCommand("api originate /sofia/gateway/yogisip"
                        " 100 XML default elcid +1234 60"),
-            FixtureReply("+OK uuid-1234"))
+            FixtureApiResponse("+OK uuid-1234"))
 
         msg = self.tx_helper.make_outbound(
             'foobar', '12345', '54321', session_event='new')
@@ -354,7 +352,7 @@ class TestVoiceClientTransport(VumiTestCase):
         factory.add_fixture(
             EslCommand("api originate /sofia/gateway/yogisip"
                        " 100 XML default elcid +1234 60"),
-            FixtureReply("+ERROR Bad horse."))
+            FixtureApiResponse("+ERROR Bad horse."))
 
         msg = self.tx_helper.make_outbound(
             'foobar', '12345', '54321', session_event='new')

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -162,7 +162,7 @@ class TestFreeSwitchESLProtocol(VumiTestCase):
             ])
 
 
-class TestVoiceServerTransport(VumiTestCase):
+class TestVoiceServerTransportInboundCalls(VumiTestCase):
 
     transport_class = VoiceServerTransport
     transport_type = 'voice'
@@ -298,7 +298,7 @@ class TestVoiceServerTransport(VumiTestCase):
                          "Client u'test-uuid' no longer connected")
 
 
-class TestVoiceClientTransport(VumiTestCase):
+class TestVoiceServerTransportOutboundCalls(VumiTestCase):
 
     transport_class = VoiceServerTransport
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -216,7 +216,7 @@ class VoiceServerTransportConfig(Transport.CONFIG_CLASS):
                 " given.")
         if any(outbound_supplied):
             try:
-                OriginateFormatter.format_template(**self.originate_parameters)
+                OriginateFormatter(**self.originate_parameters)
             except OriginateMissingParameter as err:
                 raise ConfigError(str(err))
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -9,18 +9,24 @@ through as a vumi message
 import md5
 import os
 
-from twisted.internet.protocol import ServerFactory, ClientFactory
+from twisted.internet.protocol import ServerFactory
 from twisted.internet.defer import (
-    inlineCallbacks, Deferred, gatherResults, returnValue)
+    inlineCallbacks, Deferred, gatherResults)
 from twisted.internet.utils import getProcessOutput
 from twisted.python import log
 
 from eventsocket import EventProtocol
 
+from confmodel.errors import ConfigError
+from confmodel.fields import ConfigText, ConfigDict
+
 from vumi.transports import Transport
 from vumi.message import TransportUserMessage
-from vumi.config import ConfigClientEndpoint, ConfigServerEndpoint, ConfigText
+from vumi.config import ConfigClientEndpoint, ConfigServerEndpoint
 from vumi.errors import VumiError
+
+from vxfreeswitch.originate import (
+    OriginateFormatter, OriginateMissingParameter)
 
 
 class VoiceError(VumiError):
@@ -132,64 +138,6 @@ class FreeSwitchESLProtocol(EventProtocol):
         log.msg("Unbound event %r" % (evname,))
 
 
-class ClientConnectError(Exception):
-    """Error for when a call could not be established."""
-
-
-class FreeSwitchESLClientProtocol(FreeSwitchESLProtocol):
-    def __init__(self, vumi_transport, number):
-        FreeSwitchESLProtocol.__init__(self, vumi_transport)
-        self.uniquecallid = number
-        self.job_queue = {}
-        self.ready = Deferred()
-
-    @inlineCallbacks
-    def connectionMade(self):
-        yield self.eventplain("BACKGROUND_JOB CHANNEL_HANGUP")
-        yield self.vumi_transport.register_client(self, send_inbound=False)
-        self.ready.callback(self)
-
-    def make_call(self):
-        def _success(ev):
-            response = self.job_queue[ev.Job_UUID] = Deferred()
-            return response
-
-        def _error(f):
-            if f.check(ClientConnectError):
-                return f
-            raise ClientConnectError(str(f.value))
-
-        profile = self.vumi_transport.config.sofia_profile
-        call_url = "sofia/%s/%s" % (profile, self.uniquecallid)
-        d = self.bgapi("originate %s" % (call_url))
-        d.addCallback(_success)
-        d.addErrback(_error)
-        return d
-
-    def onBackgroundJob(self, ev):
-        d = self.job_queue.pop(ev.Job_UUID, None)
-        if d:
-            response, content = ev.rawresponse.split()
-            if response == "+OK":
-                d.callback(content)
-            else:
-                d.errback(ClientConnectError(ev.rawresponse.strip()))
-
-    @inlineCallbacks
-    def onChannelHangup(self, ev):
-        self.vumi_transport.deregister_client(self)
-        yield self.transport.loseConnection()
-
-
-class DialerFactory(ClientFactory):
-    def __init__(self, vumi_transport, number):
-        self.vumi_transport = vumi_transport
-        self.number = number
-
-    def protocol(self):
-        return FreeSwitchESLClientProtocol(self.vumi_transport, self.number)
-
-
 class VoiceServerTransportConfig(Transport.CONFIG_CLASS):
     """
     Configuration parameters for the voice transport
@@ -233,15 +181,44 @@ class VoiceServerTransportConfig(Transport.CONFIG_CLASS):
         " will connect to).",
         required=True, default="tcp:port=8084", static=True)
 
-    twisted_client_endpoint = ConfigClientEndpoint(
-        "The endpoint the voice transport will send commands to (and that "
-        "Freeswitch will listen to).",
+    freeswitch_endpoint = ConfigClientEndpoint(
+        "The endpoint the voice transport will send originate commands"
+        "to (and that Freeswitch listens on).",
         required=True, default=None, static=True)
 
-    sofia_profile = ConfigText(
-        "The name of the sofia profile defined in sofia.conf.xml in "
-        "FreeSwitch.",
-        default="$${profile}", static=True)
+    freeswitch_auth = ConfigText(
+        "Password for connecting to the Freeswitch endpoint."
+        " None means no authentication credentials are offered.",
+        required=True, default=None, static=True)
+
+    originate_parameters = ConfigDict(
+        "The parameters to pass to the originate command when initiating"
+        " outbound calls. This dictionary of parameters is passed to the"
+        " originate call template:\n\n"
+        "  %(template)r\n\n"
+        "All call parameters are required but the following defaults are"
+        " supplied:\n\n"
+        "  %(defaults)r" % {
+            'template': OriginateFormatter.PROTO_TEMPLATE,
+            'defaults': OriginateFormatter.DEFAULT_PARAMS,
+        },
+        required=True, default=None, static=True)
+
+    def post_validate(self):
+        super(VoiceServerTransportConfig, self).post_validate()
+        outbound_supplied = (
+            self.freeswitch_endpoint is None,
+            self.originate_parameters is None)
+        if any(outbound_supplied) and not all(outbound_supplied):
+            raise ConfigError(
+                "If any outbound message parameters are supplied"
+                " (freeswitch_endpoint or originate_params), all must be"
+                " given.")
+        if any(outbound_supplied):
+            try:
+                OriginateFormatter.format_template(**self.originate_parameters)
+            except OriginateMissingParameter as err:
+                raise ConfigError(str(err))
 
 
 class VoiceServerTransport(Transport):
@@ -306,16 +283,7 @@ class VoiceServerTransport(Transport):
         self.voice_server = yield self.config.twisted_endpoint.listen(factory)
 
     @inlineCallbacks
-    def create_dialer_client(self, number):
-        factory = DialerFactory(self, number)
-        voice_client = yield (
-            self.config.twisted_client_endpoint.connect(factory))
-        yield voice_client.ready
-        returnValue(voice_client)
-
-    @inlineCallbacks
     def teardown_transport(self):
-        log.msg("TRACE: Tear Down Transport Start")
         if hasattr(self, 'voice_server'):
             # We need to wait for all the client connections to be closed (and
             # their deregistration messages sent) before tearing down the rest
@@ -326,16 +294,15 @@ class VoiceServerTransport(Transport):
             self.voice_server.loseConnection()
             yield wait_for_closed
 
-    def register_client(self, client, send_inbound=True):
+    def register_client(self, client):
         # We add our own Deferred to the client here because we only want to
         # fire it after we're finished with our own deregistration process.
         client.registration_d = Deferred()
         client_addr = client.get_address()
         log.msg("Registering client connected from %r" % client_addr)
         self._clients[client_addr] = client
-        if send_inbound:
-            self.send_inbound_message(
-                client, None, TransportUserMessage.SESSION_NEW)
+        self.send_inbound_message(
+            client, None, TransportUserMessage.SESSION_NEW)
         log.msg("Register completed")
 
     def deregister_client(self, client):
@@ -374,16 +341,17 @@ class VoiceServerTransport(Transport):
         if (client is None and message.get('session_event') ==
                 TransportUserMessage.SESSION_NEW):
             try:
-                client = yield self.create_dialer_client(client_addr)
-                yield client.make_call()
-            except ClientConnectError as e:
+                # save call-id and stash for handling in inbound so
+                # we can fire the ack or nack when the message is returned
+                yield self.dial_outbound(client_addr)
+            except OutboundDialerError as e:
                 log.msg("Error connecting to client %r: %s" % (
                     client_addr, e))
                 yield self.publish_nack(
                     message["message_id"],
                     "Could not make call to client %r" % (client_addr,))
                 self.deregister_client(client)
-                return
+            return
 
         if client is None:
             yield self.publish_nack(

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -1,9 +1,15 @@
 # -*- test-case-name: vxfreeswitch.tests.test_voice -*-
 
-"""
-Transport that sends text as voice to a standard SIP client via
-the Freeswitch ESL interface. Keypad input from the phone is sent
-through as a vumi message
+"""A Vumi transport for connecting to SIP gateways via FreeSWITCH's ESL
+interfaces.
+
+If outbound messages provide a URL to a pre-recorded audio message,
+that is played via SIP. Otherwise sound is generated using a
+text-to-speech engine.
+
+DTMF digits dialed on the phone are collected by the transport and
+sent as inbound messages. Digits may either be sent through individually
+(the default) or collected until a specified character is pressed.
 """
 
 import md5
@@ -13,7 +19,6 @@ from twisted.internet.protocol import ServerFactory
 from twisted.internet.defer import (
     inlineCallbacks, Deferred, gatherResults)
 from twisted.internet.utils import getProcessOutput
-from twisted.python import log
 
 from eventsocket import EventProtocol
 
@@ -24,9 +29,11 @@ from vumi.transports import Transport
 from vumi.message import TransportUserMessage
 from vumi.config import ConfigClientEndpoint, ConfigServerEndpoint
 from vumi.errors import VumiError
+from vumi import log
 
 from vxfreeswitch.originate import (
     OriginateFormatter, OriginateMissingParameter)
+from vxfreeswitch.client import FreeSwitchClient, FreeSwitchClientError
 
 
 class VoiceError(VumiError):
@@ -138,6 +145,15 @@ class FreeSwitchESLProtocol(EventProtocol):
         log.msg("Unbound event %r" % (evname,))
 
 
+class FreeSwitchESLFactory(ServerFactory):
+    """ FreeSwitch ESL server factory. """
+    def __init__(self, vumi_transport):
+        self.vumi_transport = vumi_transport
+
+    def protocol(self):
+        return FreeSwitchESLProtocol(self.vumi_transport)
+
+
 class VoiceServerTransportConfig(Transport.CONFIG_CLASS):
     """
     Configuration parameters for the voice transport
@@ -184,12 +200,12 @@ class VoiceServerTransportConfig(Transport.CONFIG_CLASS):
     freeswitch_endpoint = ConfigClientEndpoint(
         "The endpoint the voice transport will send originate commands"
         "to (and that Freeswitch listens on).",
-        required=True, default=None, static=True)
+        default=None, static=True)
 
     freeswitch_auth = ConfigText(
         "Password for connecting to the Freeswitch endpoint."
         " None means no authentication credentials are offered.",
-        required=True, default=None, static=True)
+        default=None, static=True)
 
     originate_parameters = ConfigDict(
         "The parameters to pass to the originate command when initiating"
@@ -202,19 +218,23 @@ class VoiceServerTransportConfig(Transport.CONFIG_CLASS):
             'template': OriginateFormatter.PROTO_TEMPLATE,
             'defaults': OriginateFormatter.DEFAULT_PARAMS,
         },
-        required=True, default=None, static=True)
+        default=None, static=True)
+
+    @property
+    def supports_outbound(self):
+        return self.freeswitch_endpoint is not None
 
     def post_validate(self):
         super(VoiceServerTransportConfig, self).post_validate()
-        outbound_supplied = (
-            self.freeswitch_endpoint is None,
-            self.originate_parameters is None)
-        if any(outbound_supplied) and not all(outbound_supplied):
+        required_outbound = (
+            self.freeswitch_endpoint is not None,
+            self.originate_parameters is not None)
+        if self.supports_outbound and not all(required_outbound):
             raise ConfigError(
                 "If any outbound message parameters are supplied"
                 " (freeswitch_endpoint or originate_params), all must be"
                 " given.")
-        if any(outbound_supplied):
+        if self.originate_parameters is not None:
             try:
                 OriginateFormatter(**self.originate_parameters)
             except OriginateMissingParameter as err:
@@ -246,14 +266,6 @@ class VoiceServerTransport(Transport):
       transport config) the voice transport will timeout the wait
       and send the characters entered so far.
 
-      .. todo:
-
-         Maybe ``wait_for`` should default to ``#``? It's not
-         discoverable but at least it makes it possible to enter
-         multi-digit numbers by default and it's probably simpler
-         to add a bit of help text to an application that to
-         update it to send ``helper_metadata``.
-
     Example ``helper_metadata``::
 
       "helper_metadata": {
@@ -268,19 +280,24 @@ class VoiceServerTransport(Transport):
 
     @inlineCallbacks
     def setup_transport(self):
-        log.msg("TRACE: Set Up Transport")
         self._clients = {}
+        self._originated_calls = {}
 
         self.config = self.get_static_config()
         self._to_addr = self.config.to_addr
         self._transport_type = "voice"
 
-        def protocol():
-            return FreeSwitchESLProtocol(self)
+        if self.config.supports_outbound:
+            self.voice_client = FreeSwitchClient(
+                self.config.freeswitch_endpoint, self.config.freeswitch_auth)
+            self.originate_formatter = OriginateFormatter(
+                **self.config.originate_parameters)
+        else:
+            self.voice_client = None
+            self.originate_formatter = None
 
-        factory = ServerFactory()
-        factory.protocol = protocol
-        self.voice_server = yield self.config.twisted_endpoint.listen(factory)
+        self.voice_server = yield self.config.twisted_endpoint.listen(
+            FreeSwitchESLFactory(self))
 
     @inlineCallbacks
     def teardown_transport(self):
@@ -288,35 +305,41 @@ class VoiceServerTransport(Transport):
             # We need to wait for all the client connections to be closed (and
             # their deregistration messages sent) before tearing down the rest
             # of the transport.
-            log.msg("TRACE: self._clients=%s" % (self._clients,))
-            wait_for_closed = gatherResults([
-                client.registration_d for client in self._clients.values()])
+            log.info("Shutting down %d clients." % len(self._clients))
             self.voice_server.loseConnection()
-            yield wait_for_closed
+            yield gatherResults([
+                client.registration_d for client in self._clients.values()])
 
+    @inlineCallbacks
     def register_client(self, client):
         # We add our own Deferred to the client here because we only want to
         # fire it after we're finished with our own deregistration process.
         client.registration_d = Deferred()
         client_addr = client.get_address()
-        log.msg("Registering client connected from %r" % client_addr)
+        log.info("Registering client connected from %r" % (client_addr,))
         self._clients[client_addr] = client
-        self.send_inbound_message(
-            client, None, TransportUserMessage.SESSION_NEW)
-        log.msg("Register completed")
+        originated_msg = self._originated_calls.pop(client_addr, None)
+        if originated_msg is not None:
+            yield self.send_outbound_message(client, originated_msg)
+        else:
+            self.send_inbound_message(
+                client, None, TransportUserMessage.SESSION_NEW)
+        log.info("Registration complete.")
 
     def deregister_client(self, client):
-        log.msg("TRACE: Deregistering client.")
         client_addr = client.get_address()
-        if client_addr in self._clients:
-            del self._clients[client_addr]
-            self.send_inbound_message(
-                client, None, TransportUserMessage.SESSION_CLOSE)
-            client.registration_d.callback(None)
+        if client_addr not in self._clients:
+            return
+        log.info("Deregistering client connected from %r" % (client_addr,))
+        del self._clients[client_addr]
+        self.send_inbound_message(
+            client, None, TransportUserMessage.SESSION_CLOSE)
+        client.registration_d.callback(None)
+        log.info("Deregistration complete.")
 
     def handle_input(self, client, text):
-        self.send_inbound_message(client, text,
-                                  TransportUserMessage.SESSION_RESUME)
+        self.send_inbound_message(
+            client, text, TransportUserMessage.SESSION_RESUME)
 
     def send_inbound_message(self, client, text, session_event):
         self.publish_message(
@@ -329,37 +352,13 @@ class VoiceServerTransport(Transport):
         )
 
     @inlineCallbacks
-    def handle_outbound_message(self, message):
-        text = message['content']
-        if text is None:
-            text = u''
-        text = u"\n".join(text.splitlines())
+    def send_outbound_message(self, client, message):
+        content = message['content']
+        if content is None:
+            content = u''
+        content = u"\n".join(content.splitlines())
+        content = content.encode('utf-8')
 
-        client_addr = message['to_addr']
-        client = self._clients.get(client_addr)
-
-        if (client is None and message.get('session_event') ==
-                TransportUserMessage.SESSION_NEW):
-            try:
-                # save call-id and stash for handling in inbound so
-                # we can fire the ack or nack when the message is returned
-                yield self.dial_outbound(client_addr)
-            except OutboundDialerError as e:
-                log.msg("Error connecting to client %r: %s" % (
-                    client_addr, e))
-                yield self.publish_nack(
-                    message["message_id"],
-                    "Could not make call to client %r" % (client_addr,))
-                self.deregister_client(client)
-            return
-
-        if client is None:
-            yield self.publish_nack(
-                message["message_id"],
-                "Client %r no longer connected" % (client_addr,))
-            return
-
-        text = text.encode('utf-8')
         overrideURL = None
         client.set_input_type(None)
         if 'helper_metadata' in message:
@@ -370,7 +369,7 @@ class VoiceServerTransport(Transport):
                 overrideURL = voicemeta.get('speech_url', None)
 
         if overrideURL is None:
-            yield client.output_message("%s\n" % text)
+            yield client.output_message("%s\n" % content)
         else:
             yield client.output_stream(overrideURL)
 
@@ -378,3 +377,38 @@ class VoiceServerTransport(Transport):
             client.close_call()
 
         yield self.publish_ack(message["message_id"], message["message_id"])
+
+    @inlineCallbacks
+    def dial_outbound(self, to_addr):
+        yield self.voice_client.api(
+            self.originate_formatter.format_call(self._to_addr, to_addr))
+
+    @inlineCallbacks
+    def handle_outbound_message(self, message):
+
+        client_addr = message['to_addr']
+        client = self._clients.get(client_addr)
+
+        if (self.config.supports_outbound and
+            client is None and
+            message.get('session_event') ==
+                TransportUserMessage.SESSION_NEW):
+            try:
+                yield self.dial_outbound(client_addr)
+            except FreeSwitchClientError as e:
+                log.msg("Error connecting to client %r: %s" % (
+                    client_addr, e))
+                yield self.publish_nack(
+                    message["message_id"],
+                    "Could not make call to client %r" % (client_addr,))
+            else:
+                self._originated_calls[client_addr] = message
+            return
+
+        if client is None:
+            yield self.publish_nack(
+                message["message_id"],
+                "Client %r no longer connected" % (client_addr,))
+            return
+
+        yield self.send_outbound_message(client, message)


### PR DESCRIPTION
Currently the outbound voice calls don't work with Freeswitch. We need to add:

- [x] Add authentication support to the Freeswitch client.
- [x] `originate` results in an inbound call to our server, so we shouldn't / can't handle the call inside the ESL client.
- [x] `originate` has quite complex parameters and we need to allow those to be specified because they're very dependent on Freeswitch configuration.
- [x] Once we receive the call initiated by `originate`, we need to send an ack for the message. This requires creating the call uuid before calling `originate` (so that we have it before we can possibly receive the call).
- [ ] ~~Consider using a persistent Freeswitch client.~~ (idea discarded for now)
- [ ] Address issue #3.
- [ ] Document things (especially the Freeswitch configuration needed to connect to Twilio and a suitable transport config to use with the Freeswitch configuration). See #15.