### PR TITLE
Wait for answer before playing media

### DIFF
--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -247,6 +247,11 @@ class FakeFreeSwitchProtocol(LineReceiver):
     def sendDisconnectEvent(self):
         self.sendLine('Content-Type: text/disconnect-notice\n\n')
 
+    def sendChannelAnswerEvent(self):
+        self.sendPlainEvent('Channel_Answer', {
+            'Variable-Caller-ID': self.call_uuid
+        })
+
     def rawDataReceived(self, data):
         for cmd in self.esl_parser.parse(data):
             if cmd.cmd_type == "connect":

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -468,3 +468,31 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         self.assertEqual(nack['user_message_id'], msg['message_id'])
         self.assertEqual(nack['nack_reason'],
                          "Could not make call to client u'54321'")
+
+    @inlineCallbacks
+    def test_client_disconnect_without_answer(self):
+        factory = yield self.esl_helper.mk_server()
+        factory.add_fixture(
+            EslCommand("api originate /sofia/gateway/yogisip"
+                       " 100 XML default elcid +1234 60"),
+            FixtureApiResponse("+OK uuid-1234"))
+
+        msg = self.tx_helper.make_outbound(
+            'foobar', '12345', '54321', session_event='new')
+
+        client = yield self.esl_helper.mk_client(self.worker, 'uuid-1234')
+
+        with LogCatcher(log_level=logging.WARN) as lc:
+            yield self.tx_helper.dispatch_outbound(msg)
+
+        self.assertEqual(lc.messages(), [])
+
+        events = yield self.tx_helper.get_dispatched_events()
+        self.assertEqual(events, [])
+
+        client.sendDisconnectEvent()
+
+        [nack] = yield self.tx_helper.wait_for_dispatched_events(1)
+        self.assertEqual(nack['event_type'], 'nack')
+        self.assertEqual(nack['nack_reason'], 'Unanswered Call')
+        self.assertEqual(nack['user_message_id'], msg['message_id'])

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -327,7 +327,6 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
         self.assertEqual(ack['user_message_id'], msg['message_id'])
         self.assertEqual(ack['sent_message_id'], msg['message_id'])
 
-
     @inlineCallbacks
     def test_speech_url_invalid_url(self):
         url = 7
@@ -335,7 +334,7 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
             [reg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
             self.tx_helper.clear_dispatched_inbound()
 
-            msg = yield self.tx_helper.make_dispatch_reply(
+            yield self.tx_helper.make_dispatch_reply(
                 reg, 'speech url test', helper_metadata={
                     'voice': {
                         'speech_url': url
@@ -428,6 +427,8 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         msg = self.tx_helper.make_outbound(
             'foobar', '12345', '54321', session_event='new')
 
+        client = yield self.esl_helper.mk_client(self.worker, 'uuid-1234')
+
         with LogCatcher(log_level=logging.WARN) as lc:
             yield self.tx_helper.dispatch_outbound(msg)
         self.assertEqual(lc.messages(), [])
@@ -435,7 +436,8 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         events = yield self.tx_helper.get_dispatched_events()
         self.assertEqual(events, [])
 
-        client = yield self.esl_helper.mk_client(self.worker, 'uuid-1234')
+        client.sendChannelAnswerEvent()
+
         cmd = yield client.queue.get()
         self.assertEqual(cmd, EslCommand.from_dict({
             'type': 'sendmsg', 'name': 'speak', 'arg': 'foobar .',

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -149,6 +149,10 @@ class FreeSwitchESLProtocol(EventProtocol):
         log.msg("Channel disconnect received")
         self.vumi_transport.deregister_client(self)
 
+    def onChannelAnswer(self, ev):
+        log.msg("Channel answered")
+        self.vumi_transport.client_answered(self)
+
     def unboundEvent(self, evdata, evname):
         log.msg("Unbound event %r" % (evname,))
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -290,6 +290,7 @@ class VoiceServerTransport(Transport):
     def setup_transport(self):
         self._clients = {}
         self._originated_calls = {}
+        self._unanswered_channels = {}
 
         self.config = self.get_static_config()
         self._to_addr = self.config.to_addr
@@ -336,10 +337,17 @@ class VoiceServerTransport(Transport):
 
     def deregister_client(self, client, duration=None):
         client_addr = client.get_address()
+
+        # If originated call has not yet been answered
+        if self._unanswered_channels.get(client_addr):
+            d = self._unanswered_channels[client_addr]
+            d.errback(FreeSwitchClientError('Call is unanswered'))
+
         if client_addr not in self._clients:
             return
         log.info("Deregistering client connected from %r" % (client_addr,))
         del self._clients[client_addr]
+
         self.send_inbound_message(
             client, None, TransportUserMessage.SESSION_CLOSE, duration)
         client.registration_d.callback(None)
@@ -383,6 +391,15 @@ class VoiceServerTransport(Transport):
                 client.set_input_type(voicemeta.get('wait_for', None))
                 overrideURL = voicemeta.get('speech_url', None)
 
+        # Wait if call isn't answered
+        if self._unanswered_channels.get(client.get_address()):
+            try:
+                yield self._unanswered_channels.pop(client.get_address())
+            except FreeSwitchClientError:
+                yield self.publish_nack(
+                    message['message_id'], 'Unanswered Call')
+                returnValue(None)
+
         if overrideURL is None:
             yield client.output_message("%s\n" % content)
         elif isinstance(overrideURL, basestring):
@@ -396,11 +413,20 @@ class VoiceServerTransport(Transport):
         else:
             log.warning("Invalid URL %r" % overrideURL)
 
-
         if message['session_event'] == TransportUserMessage.SESSION_CLOSE:
             client.close_call()
 
         yield self.publish_ack(message["message_id"], message["message_id"])
+
+    def client_answered(self, client):
+        """Function that is called when the ChannelAnswer event is received.
+        Fires the deferred related to the outbound call"""
+        d = self._unanswered_channels.pop(client.get_address(), None)
+        if d:
+            d.callback(None)
+        else:
+            log.warning(
+                'Cannot find unanswered channel for %r' % client.get_address())
 
     @inlineCallbacks
     def dial_outbound(self, to_addr):
@@ -408,6 +434,7 @@ class VoiceServerTransport(Transport):
         log.info("Dialing outbound via Freeswitch ESL: %r" % command)
         reply = yield self.voice_client.api(command)
         call_uuid = reply.args[1]
+        self._unanswered_channels[call_uuid] = Deferred()
         returnValue(call_uuid)
 
     @inlineCallbacks


### PR DESCRIPTION
When dialling outbound, at the moment as soon as we get a connection we start playing the message. We should rather first wait for the user to pick up and then play the first message. The easiest way to implement this would probably be to wait on the http://wiki.freeswitch.org/wiki/Event_List#CHANNEL_ANSWER event.