### PR TITLE
Support for barge-ins and message repeats.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 matrix:
   include:

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ may contain the following keys:
     A boolean value that if ``True``, stops the playback of the message when
     a DTMF character arrives. This allows the response to the input to be
     played immediately, rather than waiting for the first message to finish
-    playing before hearing the response message.
+    playing before hearing the response message. Defaults to ``False``.
 :``tries``:
    If ``barge_in`` is ``True``, this will set the amount of times a message is
    played if no input is received. Defaults to ``1``.

--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,35 @@ You can contact the Vumi development team in the following ways:
 
 Issues can be filed in the GitHub issue tracker. Please don't use the issue
 tracker for general support queries.
+
+Usage
+-----
+
+Voice transports may receive additional hints for how to handle outbound
+messages the ``voice`` section of ``helper_metadata``. The ``voice`` section
+may contain the following keys:
+
+:``speech_url``:
+    The URL where the voice file to be played can be found. If this field is
+    absent or ``None``, a text-to-speech engine will be used to generate a
+    suitable sound from the message ``content``, otherwise this voice file
+    will be played.
+
+    This can either be a string containing the URL, or a list of strings
+    containing URLs to sound files that should be joined to form the message.
+:``wait_for``:
+    Gather response characters until the given DTMF character is encountered.
+    Commonly either ``#`` or ``*``. If absent or ``None``, an inbound message
+    is sent as soon as a single DTMF character arrives.
+:``barge_in``:
+    A boolean value that if ``True``, stops the playback of the message when
+    a DTMF character arrives. This allows the response to the input to be
+    played immediately, rather than waiting for the first message to finish
+    playing before hearing the response message.
+:``tries``:
+   If ``barge_in`` is ``True``, this will set the amount of times a message is
+   played if no input is received. Defaults to ``1``.
+:``time_gap``:
+   If ``barge_in`` is ``True`` and ``tries`` is greater than ``1``, this
+   specifies the time gap (in ms) that is given before repeating the message,
+   if no DTMF characters are received. Defaults to ``3000``.

--- a/README.rst
+++ b/README.rst
@@ -55,3 +55,20 @@ may contain the following keys:
    If ``barge_in`` is ``True`` and ``tries`` is greater than ``1``, this
    specifies the time gap (in ms) that is given before repeating the message,
    if no DTMF characters are received. Defaults to ``3000``.
+
+Example:
+
+::
+
+    "helper_metadata": {
+        "voice": {
+            "speech_url": [
+                "http://www.example.com/voice/ab34f611cdee.ogg",
+                "http://www.example.com/voice/cd43f622dcef.ogg"
+            ],
+            "wait_for": "#",
+            "barge_in": True,
+            "tries": 3,
+            "time_gap": 5000,
+        },
+    }

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Usage
 -----
 
 Voice transports may receive additional hints for how to handle outbound
-messages the ``voice`` section of ``helper_metadata``. The ``voice`` section
+messages in the ``voice`` section of ``helper_metadata``. The ``voice`` section
 may contain the following keys:
 
 :``speech_url``:
@@ -49,12 +49,12 @@ may contain the following keys:
     played immediately, rather than waiting for the first message to finish
     playing before hearing the response message. Defaults to ``False``.
 :``tries``:
-   If ``barge_in`` is ``True``, this will set the amount of times a message is
+   If ``barge_in`` is ``True``, this will set the number of times a message is
    played if no input is received. Defaults to ``1``.
 :``time_gap``:
    If ``barge_in`` is ``True`` and ``tries`` is greater than ``1``, this
-   specifies the time gap (in ms) that is given before repeating the message,
-   if no DTMF characters are received. Defaults to ``3000``.
+   specifies the length of the pause (in ms) that is given before repeating
+   the message, if no DTMF characters are received. Defaults to ``3000``.
 
 Example:
 

--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -2,8 +2,6 @@
 
 from uuid import uuid4
 
-from vxfreeswitch.voice import FreeSwitchESLProtocol
-
 from zope.interface import implements
 
 import time
@@ -221,7 +219,6 @@ class FakeFreeSwitchProtocol(LineReceiver):
     def sendPlainEvent(self, name, params=None):
         params = {} if params is None else params
         params['Event-Name'] = name
-        params['variable_call_uuid'] = self.call_uuid
         data = "\n".join("%s: %s" % (k, v) for k, v in params.items()) + "\n"
         self.sendLine(
             'Content-Length: %d\nContent-Type: text/event-plain\n\n%s' %
@@ -269,18 +266,12 @@ class FakeFreeSwitchProtocol(LineReceiver):
                     self.queue.put(cmd)
                 elif cmd_name == "playback":
                     self.queue.put(cmd)
-                elif cmd_name == 'play_and_get_digits':
+                elif cmd_name == "play_and_get_digits":
                     self.queue.put(cmd)
 
     def connectionLost(self, reason):
         self.connected = False
         self.disconnect_d.callback(None)
-
-    def sendPlayAndGetDigitsComplete(self, result):
-        self.sendPlainEvent('Channel_Execute_Complete', {
-            'Application': 'play_and_get_digits',
-            'variable_%s' % FreeSwitchESLProtocol.VAR_NAME: result,
-        })
 
 
 class EslHelper(object):

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -94,15 +94,14 @@ class TestFreeSwitchESLProtocol(VumiTestCase):
     @inlineCallbacks
     def assert_and_reply_get_digits(self, msg, **kwargs):
         params = {
-            'minimum': 1, 'maximum': 1, 'timeout': 3000, 'terminator': "' '",
+            'minimum': 1, 'maximum': 1, 'timeout': 3000, 'terminator': "''",
             'tries': 1, 'msg': msg,
         }
         params.update(kwargs)
         yield self.assert_and_reply({
             "type": "sendmsg", "name": "play_and_get_digits",
             "arg": ("%(minimum)d %(maximum)d %(tries)d %(timeout)d "
-                    "%(terminator)s %(msg)s silence_stream://1 digits "
-                    "[\\d\\*#]*") % params,
+                    "%(terminator)s %(msg)s silence_stream://1") % params,
         }, "+OK")
 
     def test_create_tts_command(self):
@@ -233,15 +232,14 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
 
     def assert_get_digits_command(self, cmd, msg, **kwargs):
         params = {
-            'minimum': 1, 'maximum': 1, 'timeout': 3000, 'terminator': "' '",
+            'minimum': 1, 'maximum': 1, 'timeout': 3000, 'terminator': "''",
             'tries': 1, 'msg': msg,
         }
         params.update(kwargs)
         self.assertEqual(cmd, EslCommand.from_dict({
             'type': 'sendmsg', 'name': 'play_and_get_digits',
             "arg": ("%(minimum)d %(maximum)d %(tries)d %(timeout)d "
-                    "%(terminator)s %(msg)s silence_stream://1 digits "
-                    "[\\d\\*#]*") % params,
+                    "%(terminator)s %(msg)s silence_stream://1") % params,
         }))
 
     @inlineCallbacks

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -456,6 +456,8 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
 
     @inlineCallbacks
     def test_barge_in_defaults(self):
+        '''Barge ins should use the play_and_get_digits command with certain
+        default values.'''
         [reg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
         self.tx_helper.clear_dispatched_inbound()
 
@@ -471,6 +473,8 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
 
     @inlineCallbacks
     def test_barge_in_non_defaults(self):
+        '''When the correct fields are specified, these should override the
+        defaults.'''
         [reg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
         self.tx_helper.clear_dispatched_inbound()
 
@@ -490,7 +494,9 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
             terminator='#', tries=2, timeout=5000)
 
     @inlineCallbacks
-    def test_barge_in_ignores_single_digits(self):
+    def test_barge_in_collecting_digits(self):
+        '''If we send a barge in message, we should collect the digits that
+        the client has sent us.'''
         [reg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
         self.tx_helper.clear_dispatched_inbound()
 
@@ -503,12 +509,11 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
             })
 
         self.client.sendDtmfEvent('5')
+        self.client.sendDtmfEvent('6')
         self.client.sendDtmfEvent('#')
 
-        self.client.sendPlayAndGetDigitsComplete('6#')
-
         [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
-        self.assertEqual(msg['content'], '6#')
+        self.assertEqual(msg['content'], '56')
 
 
 class TestVoiceServerTransportOutboundCalls(VumiTestCase):

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -208,6 +208,17 @@ class TestFreeSwitchESLProtocol(VumiTestCase):
             'foo', minimum=0, maximum=128, tries=2, timeout=5000,
             terminator='#')
 
+    @inlineCallbacks
+    def test_send_text_as_speech_quote_escaping(self):
+        '''If there are any single quotes in the text that we are converting
+        to speech, we should escape those quotes before sending it to
+        freeswitch, since we send the text string within single quotes.'''
+        d = self.proto.send_text_as_speech(
+            "thomas", "his_masters_voice", "text with single quote's")
+        yield self.assert_and_reply_tts(
+            "thomas", "his_masters_voice", "text with single quote\\'s")
+        yield d
+
 
 class TestVoiceServerTransportInboundCalls(VumiTestCase):
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -82,7 +82,8 @@ class FreeSwitchESLProtocol(EventProtocol):
         return cmd, args
 
     @inlineCallbacks
-    def create_and_stream_text_as_speech(self, folder, command, ext, message):
+    def create_and_stream_text_as_speech(
+            self, folder, command, ext, message, settings={}):
         key = md5.md5(message).hexdigest()
         filename = os.path.join(folder, "voice-%s.%s" % (key, ext))
         if not os.path.exists(filename):
@@ -92,25 +93,25 @@ class FreeSwitchESLProtocol(EventProtocol):
         else:
             log.msg("Using cached voice file %r" % (filename,))
 
-        yield self.playback(filename)
+        yield self.output_stream(filename, settings)
 
     @inlineCallbacks
-    def send_text_as_speech(self, engine, voice, message):
+    def send_text_as_speech(self, engine, voice, message, settings={}):
         yield self.set("tts_engine=" + engine)
         yield self.set("tts_voice=" + voice)
-        yield self.execute("speak", message)
+        yield self.output_stream("say:'%s'" % message, settings)
 
     @inlineCallbacks
-    def stream_text_as_speech(self, message):
+    def stream_text_as_speech(self, message, settings):
         finalmessage = message.replace("\n", " . ")
         cfg = self.vumi_transport.config
         if cfg.tts_type == "local":
             yield self.create_and_stream_text_as_speech(
                 cfg.tts_local_cache, cfg.tts_local_command,
-                cfg.tts_local_ext, finalmessage)
+                cfg.tts_local_ext, finalmessage, settings)
         elif cfg.tts_type == "freeswitch":
             yield self.send_text_as_speech(
-                cfg.tts_fs_engine, cfg.tts_fs_voice, finalmessage)
+                cfg.tts_fs_engine, cfg.tts_fs_voice, finalmessage, settings)
         else:
             raise VoiceError("Unknown tts_type %r" % (
                 cfg.tts_type,))
@@ -118,13 +119,33 @@ class FreeSwitchESLProtocol(EventProtocol):
     def get_address(self):
         return self.uniquecallid
 
-    def output_message(self, text):
-        self.log("Sending text as speech: %r" % (text,))
-        return self.stream_text_as_speech(text)
+    def output_message(self, text, settings={}):
+        return self.stream_text_as_speech(text, settings=settings)
 
-    def output_stream(self, url):
-        self.log("Playing back URL: %r" % (url,))
-        return self.playback(url)
+    def output_stream(self, message, settings={}):
+        self.log("Playing back: %r" % (message,))
+        if settings.get('barge_in'):
+            self.collecting_digits = True
+            terminator = settings.get('wait_for')
+            if settings.get('wait_for') is None:
+                # We just want to get 1 digit
+                minimum, maximum = 1, 1
+                terminator = "' '"
+            else:
+                # 128 is the maximum amount of digits that freeswitch can
+                # collect
+                minimum, maximum = 0, 128
+            tries = settings.get('tries', 1)
+            timeout = settings.get('time_gap', 3000)
+            # We have to have an invalid response message, so we set it to
+            # 1ms of silence
+            invalid_message = 'silence_stream://1'
+            return self.execute('play_and_get_digits', ' '.join([
+                str(minimum), str(maximum), str(tries), str(timeout),
+                str(terminator), message, invalid_message, self.VAR_NAME,
+                r'[\d\*#]*']))
+        else:
+            return self.playback(message)
 
     def set_input_type(self, input_type):
         self.input_type = input_type
@@ -398,12 +419,10 @@ class VoiceServerTransport(Transport):
 
         overrideURL = None
         client.set_input_type(None)
-        if 'helper_metadata' in message:
-            meta = message['helper_metadata']
-            if 'voice' in meta:
-                voicemeta = meta['voice']
-                client.set_input_type(voicemeta.get('wait_for', None))
-                overrideURL = voicemeta.get('speech_url', None)
+
+        voicemeta = get_in(message, 'helper_metadata', 'voice', default={})
+        client.set_input_type(voicemeta.get('wait_for', None))
+        overrideURL = voicemeta.get('speech_url', None)
 
         # Wait if call isn't answered
         if self._unanswered_channels.get(client.get_address()):
@@ -415,13 +434,13 @@ class VoiceServerTransport(Transport):
                 returnValue(None)
 
         if overrideURL is None:
-            yield client.output_message("%s\n" % content)
+            yield client.output_message("%s\n" % content, voicemeta)
         elif isinstance(overrideURL, basestring):
-            yield client.output_stream(overrideURL)
+            yield client.output_stream(overrideURL, voicemeta)
         elif isinstance(overrideURL, list):
             try:
                 urllist = 'file_string://%s' % '!'.join(overrideURL)
-                yield client.output_stream(urllist)
+                yield client.output_stream(urllist, voicemeta)
             except TypeError:
                 error = "Invalid URL list %r" % overrideURL
                 yield self.log_and_nack(message, error)
@@ -484,3 +503,11 @@ class VoiceServerTransport(Transport):
             return
 
         yield self.send_outbound_message(client, message)
+
+
+def get_in(d, *args, **kwargs):
+    for arg in args:
+        d = d.get(arg)
+        if d is None:
+            return kwargs.get('default')
+    return d

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -41,7 +41,6 @@ class VoiceError(VumiError):
 
 
 class FreeSwitchESLProtocol(EventProtocol):
-    VAR_NAME = 'digits'
 
     def __init__(self, vumi_transport):
         EventProtocol.__init__(self)
@@ -145,8 +144,7 @@ class FreeSwitchESLProtocol(EventProtocol):
             invalid_message = 'silence_stream://1'
             return self.execute('play_and_get_digits', ' '.join([
                 str(minimum), str(maximum), str(tries), str(timeout),
-                str(terminator), message, invalid_message, self.VAR_NAME,
-                r'[\d\*#]*']))
+                str(terminator), message, invalid_message]))
         else:
             return self.playback(message)
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -99,6 +99,8 @@ class FreeSwitchESLProtocol(EventProtocol):
     def send_text_as_speech(self, engine, voice, message, settings={}):
         yield self.set("tts_engine=" + engine)
         yield self.set("tts_voice=" + voice)
+        # 'say:' is misleading here, it functions more like 'speak' in this
+        # context.
         yield self.output_stream(
             "say:'%s'" % message.replace("'", "\\'"), settings)
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -153,10 +153,15 @@ class FreeSwitchESLProtocol(EventProtocol):
     def close_call(self):
         self.request_hang_up = True
 
+    @inlineCallbacks
     def onChannelExecuteComplete(self, ev):
         self.log("execute complete " + ev.variable_call_uuid)
+        if ev.get('Application') == 'play_and_get_digits':
+            self.collecting_digits = False
+            yield self.vumi_transport.handle_input(
+                self, ev.get('variable_%s' % self.VAR_NAME))
         if self.request_hang_up:
-            return self.hangup()
+            yield self.hangup()
 
     def onChannelHangupComplete(self, ev):
         self.log("Channel HangUp")

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -419,9 +419,6 @@ class VoiceServerTransport(Transport):
         content = u"\n".join(content.splitlines())
         content = content.encode('utf-8')
 
-        overrideURL = None
-        client.set_input_type(None)
-
         voicemeta = get_in(message, 'helper_metadata', 'voice', default={})
         client.set_input_type(voicemeta.get('wait_for', None))
         overrideURL = voicemeta.get('speech_url', None)

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -128,10 +128,12 @@ class FreeSwitchESLProtocol(EventProtocol):
         self.log("Playing back: %r" % (message,))
         if settings.get('barge_in'):
             terminator = settings.get('wait_for')
-            if settings.get('wait_for') is None:
+            if terminator is None:
                 # We just want to get 1 digit
                 minimum, maximum = 1, 1
-                terminator = "' '"
+                # We don't want a terminating character, but we have to supply
+                # one, so we supply a blank one
+                terminator = "''"
             else:
                 # 128 is the maximum amount of digits that freeswitch can
                 # collect

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -100,7 +100,8 @@ class FreeSwitchESLProtocol(EventProtocol):
     def send_text_as_speech(self, engine, voice, message, settings={}):
         yield self.set("tts_engine=" + engine)
         yield self.set("tts_voice=" + voice)
-        yield self.output_stream("say:'%s'" % message, settings)
+        yield self.output_stream(
+            "say:'%s'" % message.replace("'", "\\'"), settings)
 
     @inlineCallbacks
     def stream_text_as_speech(self, message, settings):


### PR DESCRIPTION
We'd like to add support for people to respond mid-message or mid-message sequence and for messages to repeat if there is no response after some period.

Use cases:

* A person knows the option they would like to choose and selects it mid playback. We'd like to have the message playback end and for the selection to be returned to the application for processing.
* A person fails to respond and the messages is repeated to them (a configurable number of times before the transport hangs up the call and notifies the application).
* A person explicitly responds with a configurable DTMF command that asks for the message to be repeated (e.g. `*#` during a message causes the message to be repeated).

Freeswitch features that might help us implement this:

* `play-and-get-digits` (https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+play+and+get+digits)
* `play-and-detect-speech` (https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+play_and_detect_speech)
* `play`, with `playback_terminators` (https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+playback)
* `flush_dtmf` (https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+flush+dtmf)