### PR TITLE
Logging's changed in Twisted>=15, patch the relevant code until eventsocket 0.1.5 is released. (MOMNG-167)

### DIFF
--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -30,7 +30,6 @@ from vumi.transports import Transport
 from vumi.message import TransportUserMessage
 from vumi.config import ConfigClientEndpoint, ConfigServerEndpoint
 from vumi.errors import VumiError
-from vumi import log
 
 from vxfreeswitch.originate import (
     OriginateFormatter, OriginateMissingParameter)
@@ -53,12 +52,13 @@ class FreeSwitchESLProtocol(EventProtocol):
 
     # NOTE: These were lifted straight from eventsocket's github code
     #       Once https://github.com/fiorix/eventsocket/issues/11 is closed
-    #       This code (and the vumi.log import) can be undone
     def unknownContentType(self, content_type, ctx):
-        log.debug("[eventsocket] unknown Content-Type: %s" % content_type)
+        self.vumi_transport.log.debug(
+            "[eventsocket] unknown Content-Type: %s" % content_type)
 
     def unboundEvent(self, ctx, evname):
-        log.debug("[eventsocket] unbound Event: %s" % evname)
+        self.vumi_transport.log.debug(
+            "[eventsocket] unbound Event: %s" % evname)
 
     @inlineCallbacks
     def connectionMade(self):

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -30,6 +30,7 @@ from vumi.transports import Transport
 from vumi.message import TransportUserMessage
 from vumi.config import ConfigClientEndpoint, ConfigServerEndpoint
 from vumi.errors import VumiError
+from vumi import log
 
 from vxfreeswitch.originate import (
     OriginateFormatter, OriginateMissingParameter)
@@ -49,6 +50,12 @@ class FreeSwitchESLProtocol(EventProtocol):
         self.current_input = ''
         self.input_type = None
         self.uniquecallid = None
+
+    def unknownContentType(self, content_type, ctx):
+        log.debug("[eventsocket] unknown Content-Type: %s" % content_type)
+
+    def unboundEvent(self, ctx, evname):
+        log.debug("[eventsocket] unbound Event: %s" % evname)
 
     @inlineCallbacks
     def connectionMade(self):

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -50,8 +50,6 @@ class FreeSwitchESLProtocol(EventProtocol):
         self.input_type = None
         self.uniquecallid = None
 
-    # NOTE: These were lifted straight from eventsocket's github code
-    #       Once https://github.com/fiorix/eventsocket/issues/11 is closed
     def unknownContentType(self, content_type, ctx):
         self.vumi_transport.log.debug(
             "[eventsocket] unknown Content-Type: %s" % content_type)

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -51,6 +51,9 @@ class FreeSwitchESLProtocol(EventProtocol):
         self.input_type = None
         self.uniquecallid = None
 
+    # NOTE: These were lifted straight from eventsocket's github code
+    #       Once https://github.com/fiorix/eventsocket/issues/11 is closed
+    #       This code (and the vumi.log import) can be undone
     def unknownContentType(self, content_type, ctx):
         log.debug("[eventsocket] unknown Content-Type: %s" % content_type)
 


### PR DESCRIPTION
This can be undone when https://github.com/fiorix/eventsocket/issues/11 is addressed & version 0.1.5 (which has the fixes) is released to pypi.