### PR TITLE
Add config switch for waiting on call answer

### DIFF
--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -530,11 +530,12 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
 
     transport_class = VoiceServerTransport
 
-    @inlineCallbacks
     def setUp(self):
         self.tx_helper = self.add_helper(TransportHelper(self.transport_class))
         self.esl_helper = self.add_helper(EslHelper())
-        self.worker = yield self.tx_helper.get_transport({
+
+    def create_worker(self, config={}):
+        default = {
             'twisted_endpoint': 'tcp:port=0',
             'freeswitch_endpoint': 'tcp:127.0.0.1:port=1337',
             'originate_parameters': {
@@ -543,10 +544,13 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
                 'cid_name': 'elcid',
                 'cid_num': '+1234'
             },
-        })
+        }
+        default.update(config)
+        return self.tx_helper.get_transport(default)
 
     @inlineCallbacks
     def test_create_call(self):
+        self.worker = yield self.create_worker()
         factory = yield self.esl_helper.mk_server()
         factory.add_fixture(
             EslCommand("api originate /sofia/gateway/yogisip"
@@ -578,6 +582,7 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
 
     @inlineCallbacks
     def test_connect_error(self):
+        self.worker = yield self.create_worker()
         factory = yield self.esl_helper.mk_server(
             fail_connect=True, uuid=lambda: 'uuid-1234')
         factory.add_fixture(
@@ -600,6 +605,7 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
 
     @inlineCallbacks
     def test_client_disconnect_without_answer(self):
+        self.worker = yield self.create_worker()
         factory = yield self.esl_helper.mk_server()
         factory.add_fixture(
             EslCommand("api originate /sofia/gateway/yogisip"


### PR DESCRIPTION
For outbound (originated) calls, we wait for a ChannelAnswer event before starting to send any media.

With some SIP providers, however, we don't get a return from freeswitch immediately, but rather, only once the call has been answered. In this case, no ChannelAnswer event is sent, and the transport is stuck waiting for one.

The plan is to add a config switch to turn off waiting for the call to be answered, since for these SIP providers we would be doing this anyway.

See http://blog.godson.in/2010/12/use-of-returnringready-originate.html for a detailed explanation.