### PR TITLE
Set the UUID for outbound calls

### DIFF
--- a/vxfreeswitch/originate.py
+++ b/vxfreeswitch/originate.py
@@ -57,7 +57,7 @@ class OriginateFormatter(object):
     E.g. ::
 
         formatter = OriginateFormatter(
-            call_url='sofia/gateway/yogisip/{to_addr}',
+            call_url='{{origination_uuid={uuid}}}sofia/gateway/yogisip/{to_addr}',
             exten='{from_addr}',
             cid_name='vxfreeswitch',
             cid_id='{from_addr}',
@@ -85,7 +85,7 @@ class OriginateFormatter(object):
     def __init__(self, **kw):
         self.template = self.format_template(**kw)
 
-    def format_call(self, from_addr, to_addr):
+    def format_call(self, from_addr, to_addr, uuid):
         """ Return a formatted originate call.
 
         :param str from_addr:
@@ -94,11 +94,14 @@ class OriginateFormatter(object):
         :param str to_addr:
             The address the call is to.
 
+        :param str uuid:
+            The UUID that the originated call should have.
+
         :returns str:
             A formatted originate call for passing to Freeswitch.
         """
         return self.template.format(
-            from_addr=from_addr, to_addr=to_addr)
+            from_addr=from_addr, to_addr=to_addr, uuid=uuid)
 
     @classmethod
     def format_template(cls, **kw):

--- a/vxfreeswitch/tests/test_originate.py
+++ b/vxfreeswitch/tests/test_originate.py
@@ -9,7 +9,8 @@ from vxfreeswitch.originate import (
 class TestOriginateFormatter(TestCase):
     def mk_params(self, **kw):
         params = {
-            'call_url': 'sofia/gateway/yogisip/{to_addr}',
+            'call_url':
+                '{{origination_uuid={uuid}}}sofia/gateway/yogisip/{to_addr}',
             'exten': '100',
             'cid_name': 'elcid',
             'cid_num': '{from_addr}',
@@ -27,8 +28,8 @@ class TestOriginateFormatter(TestCase):
     def test_format_template(self):
         self.assertEqual(
             self.mk_template(),
-            "originate sofia/gateway/yogisip/{to_addr}"
-            " 100 XML default elcid {from_addr} 60")
+            "originate {{origination_uuid={uuid}}}sofia/gateway/yogisip/"
+            "{to_addr} 100 XML default elcid {from_addr} 60")
 
     def test_format_template_missing_parameter(self):
         err = self.assertRaises(
@@ -40,8 +41,8 @@ class TestOriginateFormatter(TestCase):
         formatter = self.mk_formatter()
         self.assertEqual(
             formatter.template,
-            "originate sofia/gateway/yogisip/{to_addr}"
-            " 100 XML default elcid {from_addr} 60")
+            "originate {{origination_uuid={uuid}}}sofia/gateway/yogisip/"
+            "{to_addr} 100 XML default elcid {from_addr} 60")
 
     def test_init_missing_parameter(self):
         err = self.assertRaises(
@@ -52,6 +53,7 @@ class TestOriginateFormatter(TestCase):
     def test_format_call(self):
         formatter = self.mk_formatter()
         self.assertEqual(
-            formatter.format_call(to_addr="+1234", from_addr="1099"),
-            "originate sofia/gateway/yogisip/+1234"
+            formatter.format_call(
+                to_addr="+1234", from_addr="1099", uuid='test-uuid'),
+            "originate {origination_uuid=test-uuid}sofia/gateway/yogisip/+1234"
             " 100 XML default elcid 1099 60")

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -26,8 +26,6 @@ from eventsocket import EventProtocol
 from confmodel.errors import ConfigError
 from confmodel.fields import ConfigText, ConfigDict, ConfigBool
 
-import uuid
-
 from vumi.transports import Transport
 from vumi.message import TransportUserMessage
 from vumi.config import ConfigClientEndpoint, ConfigServerEndpoint
@@ -485,7 +483,7 @@ class VoiceServerTransport(Transport):
 
     @inlineCallbacks
     def dial_outbound(self, to_addr):
-        call_uuid = str(uuid.uuid4())
+        call_uuid = self.generate_message_id()
         command = self.originate_formatter.format_call(
             self._to_addr, to_addr, call_uuid)
         self.log.info("Dialing outbound via Freeswitch ESL: %r" % command)


### PR DESCRIPTION
In practical testing, it seems like the connection back to us from freeswitch specifies a different UUID than the one that is sent to us during our connection to freeswitch.

The plan is to implement this using (from the freeswitch docs https://wiki.freeswitch.org/wiki/Mod_commands#originate): 

```
You can specify the UUID of an originated call by doing the following:
 - Use create_uuid to generate a UUID to use.
 - This will allow you to kill an originated call before it is answered by using uuid_kill.
 - If you specify origination_uuid it will remain the UUID for answered call leg for the whole session.

    originate {origination_uuid=...}user/100@domain.name.com
```