### PR TITLE
Don't remove unanswered call until yielded on

### DIFF
--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -530,6 +530,7 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
 class TestVoiceServerTransportOutboundCalls(VumiTestCase):
 
     transport_class = VoiceServerTransport
+    SLEEP_TIME = 0.01
 
     def setUp(self):
         self.tx_helper = self.add_helper(TransportHelper(self.transport_class))
@@ -549,6 +550,11 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         default.update(config)
         return self.tx_helper.get_transport(default)
 
+    def sleep(self, time=SLEEP_TIME):
+        d = defer.Deferred()
+        reactor.callLater(time, d.callback, None)
+        return d
+
     @inlineCallbacks
     def wait_for_client_registration(self, worker, clientid):
         '''Waits until the client has registered itself to the worker. Returns
@@ -556,9 +562,7 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         for _ in range(5):
             if worker._originated_calls.get(clientid, None) is None:
                 returnValue(True)
-            d = defer.Deferred()
-            reactor.callLater(0.01, d.callback, None)
-            yield d
+            yield self.sleep()
         returnValue(False)
 
     @inlineCallbacks
@@ -568,9 +572,7 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         for _ in range(5):
             if worker._unanswered_channels.get(callid, None) is None:
                 returnValue(True)
-            d = defer.Deferred()
-            reactor.callLater(0.01, d.callback, None)
-            yield d
+            yield self.sleep()
         returnValue(False)
 
     @inlineCallbacks

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -444,12 +444,12 @@ class VoiceServerTransport(Transport):
         if self._unanswered_channels.get(client.get_address()):
             try:
                 yield self._unanswered_channels.get(client.get_address())
-                self._unanswered_channels.pop(client.get_address())
             except FreeSwitchClientError:
                 yield self.publish_nack(
                     message['message_id'], 'Unanswered Call')
-                self._unanswered_channels.pop(client.get_address())
                 returnValue(None)
+            finally:
+                self._unanswered_channels.pop(client.get_address())
 
         if overrideURL is None:
             yield client.output_message("%s\n" % content, voicemeta)

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -443,10 +443,12 @@ class VoiceServerTransport(Transport):
         # Wait if call isn't answered
         if self._unanswered_channels.get(client.get_address()):
             try:
-                yield self._unanswered_channels.pop(client.get_address())
+                yield self._unanswered_channels.get(client.get_address())
+                self._unanswered_channels.pop(client.get_address())
             except FreeSwitchClientError:
                 yield self.publish_nack(
                     message['message_id'], 'Unanswered Call')
+                self._unanswered_channels.pop(client.get_address())
                 returnValue(None)
 
         if overrideURL is None:
@@ -474,7 +476,7 @@ class VoiceServerTransport(Transport):
     def client_answered(self, client):
         """Function that is called when the ChannelAnswer event is received.
         Fires the deferred related to the outbound call"""
-        d = self._unanswered_channels.pop(client.get_address(), None)
+        d = self._unanswered_channels.get(client.get_address(), None)
         if d:
             d.callback(None)
         else:


### PR DESCRIPTION
At the moment, we remove the unanswered call from the dictionary when the client answers. We should rather leave the unanswered call in the dictionary, and only remove it once we've yielded on it.