### PR TITLE
Use msisdn for outbound for originated calls

### DIFF
--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -677,7 +677,7 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
         client.sendChannelAnswerEvent()
         yield self.wait_for_call_answer(self.worker, 'uuid-1234')
 
-        [ack] = yield self.tx_helper.wait_for_dispatched_events()
+        [ack] = yield self.tx_helper.wait_for_dispatched_events(1)
         self.assertEqual(ack['event_type'], 'ack')
         self.assertEqual(ack['user_message_id'], msg['message_id'])
 
@@ -686,7 +686,7 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
             'foobar', '12345', '54321', session_event='close')
         yield self.tx_helper.dispatch_outbound(msg)
 
-        [ack] = yield self.tx_helper.wait_for_dispatched_events()
+        [ack] = yield self.tx_helper.wait_for_dispatched_events(1)
         self.assertEqual(ack['event_type'], 'ack')
         self.assertEqual(ack['user_message_id'], msg['message_id'])
 

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -501,7 +501,9 @@ class VoiceServerTransport(Transport):
     @inlineCallbacks
     def handle_outbound_message(self, message):
         client_addr = message['to_addr']
-        client = self._clients.get(client_addr)
+        client = self._clients.get(
+            reverse_dict_lookup(self._msisdn_mapping, client_addr) or
+            client_addr)
 
         if (self.config.supports_outbound and
             client is None and
@@ -534,3 +536,10 @@ def get_in(d, *args, **kwargs):
         if d is None:
             return kwargs.get('default')
     return d
+
+
+def reverse_dict_lookup(d, v):
+    for k, val in d.iteritems():
+        if v == val:
+            return k
+    return None


### PR DESCRIPTION
When we originate a call, any outbounds to the call we should be able to just set the to address to the msisdn that we used for the originate message, and the transport should find the appropriate session and send the message over that session.