### PR TITLE
Better error message for nack for dialling error

### DIFF
--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -702,16 +702,16 @@ class TestVoiceServerTransportOutboundCalls(VumiTestCase):
 
         msg = self.tx_helper.make_outbound(
             'foobar', '12345', '54321', session_event='new')
-        with LogCatcher(message='Error connecting') as lc:
+        with LogCatcher(message='Could not make call') as lc:
             yield self.tx_helper.dispatch_outbound(msg)
         self.assertEqual(lc.messages(), [
-            "Error connecting to client u'54321':"
-            " +ERROR Bad horse.",
+            "Could not make call to client u'54321': +ERROR Bad horse.",
         ])
         [nack] = yield self.tx_helper.get_dispatched_events()
         self.assertEqual(nack['user_message_id'], msg['message_id'])
-        self.assertEqual(nack['nack_reason'],
-                         "Could not make call to client u'54321'")
+        self.assertEqual(
+            nack['nack_reason'],
+            "Could not make call to client u'54321': +ERROR Bad horse.")
 
     @inlineCallbacks
     def test_client_disconnect_without_answer(self):

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -512,11 +512,9 @@ class VoiceServerTransport(Transport):
             try:
                 call_uuid = yield self.dial_outbound(client_addr)
             except FreeSwitchClientError as e:
-                self.log.warning("Error connecting to client %r: %s" % (
-                    client_addr, e))
-                yield self.publish_nack(
-                    message["message_id"],
-                    "Could not make call to client %r" % (client_addr,))
+                yield self.log_and_nack(
+                    message, "Could not make call to client %r: %s" % (
+                        client_addr, e))
             else:
                 self._originated_calls[call_uuid] = message
             return


### PR DESCRIPTION
Currently, we log the actual error that occurred when dialing the client, but we don't put that in the message for the nack. We should put that same error message in both the nack and the logged error message.