### PR TITLE
Add caller ID to metadata

### DIFF
--- a/vxfreeswitch/tests/test_client.py
+++ b/vxfreeswitch/tests/test_client.py
@@ -38,7 +38,7 @@ class StringClientEndpoint(object):
         try:
             protocol = factory.buildProtocol("dummy-address")
             self.transport = connect_transport(protocol, factory)
-        except:
+        except Exception:
             return fail()
         return succeed(protocol)
 

--- a/vxfreeswitch/tests/test_voice.py
+++ b/vxfreeswitch/tests/test_voice.py
@@ -320,6 +320,13 @@ class TestVoiceServerTransportInboundCalls(VumiTestCase):
         self.assertEqual(ack['sent_message_id'], msg['message_id'])
 
     @inlineCallbacks
+    def test_inbound_caller_id_number(self):
+        [reg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+        msg = yield self.tx_helper.make_dispatch_reply(reg, "voice test")
+
+        self.assertEqual(msg['helper_metadata']['caller_id_number'], "1234")
+
+    @inlineCallbacks
     def test_simpledigitcapture(self):
         yield self.tx_helper.wait_for_dispatched_inbound(1)
         self.tx_helper.clear_dispatched_inbound()

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -67,6 +67,7 @@ class FreeSwitchESLProtocol(EventProtocol):
 
     def on_connect(self, ctx):
         self.uniquecallid = ctx.variable_call_uuid
+        self.caller_id_number = ctx.caller_id_number
 
     def onDtmf(self, ev):
         if self.input_type is None:
@@ -126,6 +127,9 @@ class FreeSwitchESLProtocol(EventProtocol):
 
     def get_address(self):
         return self.uniquecallid
+
+    def get_caller_id_number(self):
+        return self.caller_id_number
 
     def output_message(self, text, settings={}):
         return self.stream_text_as_speech(text, settings=settings)
@@ -411,6 +415,8 @@ class VoiceServerTransport(Transport):
             if not helper_metadata.get('voice'):
                 helper_metadata['voice'] = voice = {}
             voice['call_duration'] = duration
+
+        helper_metadata['caller_id_number'] = client.get_caller_id_number()
 
         self.publish_message(
             from_addr=self._msisdn_mapping.get(


### PR DESCRIPTION
Adding this to the metadata because it is not very reliable, each application should deal with what happens if it is empty.

As far as I can tell it doesn't start with `variable_` because it is not a real variable but actually a read-only value.

https://wiki.freeswitch.org/wiki/Variable_caller_id_number