### PR TITLE
Fix caller id in metadata

### DIFF
--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -257,7 +257,7 @@ class FakeFreeSwitchProtocol(LineReceiver):
         for cmd in self.esl_parser.parse(data):
             if cmd.cmd_type == "connect":
                 self.sendCommandReply(
-                    'variable-call-uuid: {}\ncaller-id-number: {}'.format(
+                    'variable-call-uuid: {}\nvariable-caller-id-number: {}'.format(
                         self.call_uuid, self.caller_id_number))
             elif cmd.cmd_type == "myevents":
                 self.sendCommandReply()

--- a/vxfreeswitch/tests/helpers.py
+++ b/vxfreeswitch/tests/helpers.py
@@ -257,7 +257,8 @@ class FakeFreeSwitchProtocol(LineReceiver):
         for cmd in self.esl_parser.parse(data):
             if cmd.cmd_type == "connect":
                 self.sendCommandReply(
-                    'variable-call-uuid: {}\nvariable-caller-id-number: {}'.format(
+                    'variable-call-uuid: {}\n'
+                    'variable-caller-id-number: {}'.format(
                         self.call_uuid, self.caller_id_number))
             elif cmd.cmd_type == "myevents":
                 self.sendCommandReply()

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -67,7 +67,10 @@ class FreeSwitchESLProtocol(EventProtocol):
 
     def on_connect(self, ctx):
         self.uniquecallid = ctx.variable_call_uuid
-        self.caller_id_number = ctx.caller_id_number
+        print '----------------'
+        print ctx.keys()
+
+        self.caller_id_number = ctx.get('caller_id_number')
 
     def onDtmf(self, ev):
         if self.input_type is None:

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -67,12 +67,7 @@ class FreeSwitchESLProtocol(EventProtocol):
 
     def on_connect(self, ctx):
         self.uniquecallid = ctx.variable_call_uuid
-        print '----------------'
-        for key in ctx.keys():
-            if key.lower().find('id_number') != -1:
-                print key, ';', ctx[key]
-
-        self.caller_id_number = ctx.get('caller_id_number')
+        self.caller_id_number = ctx.get('variable_caller_id_number')
 
     def onDtmf(self, ev):
         if self.input_type is None:

--- a/vxfreeswitch/voice.py
+++ b/vxfreeswitch/voice.py
@@ -68,7 +68,9 @@ class FreeSwitchESLProtocol(EventProtocol):
     def on_connect(self, ctx):
         self.uniquecallid = ctx.variable_call_uuid
         print '----------------'
-        print ctx.keys()
+        for key in ctx.keys():
+            if key.lower().find('id_number') != -1:
+                print key, ';', ctx[key]
 
         self.caller_id_number = ctx.get('caller_id_number')
 


### PR DESCRIPTION
I added some prints and it does start with `variable_`.